### PR TITLE
Replace `if else` blocks with equivalent `match`es

### DIFF
--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -2,7 +2,7 @@ use amethyst::{
     ecs::prelude::{Component, DenseVecStorage, Entity, Entities},
     core::math::Vector3,
 };
-use std::vec::Vec;
+use std::{cmp::Ordering, vec::Vec};
 use crate::{
     constants::STATUS_BAR_Z,
 };
@@ -33,20 +33,20 @@ impl StatusBar {
         let status_divisor = max_value / self.unit_limit;
         let status_unit_num = (current_value / status_divisor).ceil() as usize;
 
-        if status_unit_num > self.status_unit_stack.len() {
-            let status_position = Vector3::new(
-                self.x_pos, self.y_pos, STATUS_BAR_Z
-            );
-            self.x_pos += 1.0;
-            return Some(status_position);
-        }else if status_unit_num < self.status_unit_stack.len() {
-            if let Some(unit) = self.status_unit_stack.pop() {
-                let _result = entities.delete(unit);
-                self.x_pos -= 1.0;
+        match status_unit_num.cmp(&self.status_unit_stack.len()) {
+            Ordering::Greater => {
+                let status_position = Vector3::new(self.x_pos, self.y_pos, STATUS_BAR_Z);
+                self.x_pos += 1.0;
+                return Some(status_position);
             }
-            return None;
-        }else {
-            return None;
+            Ordering::Less => {
+                if let Some(unit) = self.status_unit_stack.pop() {
+                    let _result = entities.delete(unit);
+                    self.x_pos -= 1.0;
+                }
+                return None;
+            }
+            Ordering::Equal => return None,
         }
     }
 
@@ -55,20 +55,20 @@ impl StatusBar {
         let status_divisor = max_value / self.unit_limit;
         let status_unit_num = (current_value / status_divisor).ceil() as usize;
 
-        if status_unit_num > self.status_unit_stack.len() {
-            let status_position = Vector3::new(
-                self.x_pos, self.y_pos, STATUS_BAR_Z
-            );
-            self.y_pos += 1.0;
-            return Some(status_position);
-        }else if status_unit_num < self.status_unit_stack.len() {
-            if let Some(unit) = self.status_unit_stack.pop() {
-                let _result = entities.delete(unit);
-                self.y_pos -= 1.0;
+        match status_unit_num.cmp(&self.status_unit_stack.len()) {
+            Ordering::Greater => {
+                let status_position = Vector3::new(self.x_pos, self.y_pos, STATUS_BAR_Z);
+                self.y_pos += 1.0;
+                return Some(status_position);
             }
-            return None;
-        }else {
-            return None;
+            Ordering::Less => {
+                if let Some(unit) = self.status_unit_stack.pop() {
+                    let _result = entities.delete(unit);
+                    self.y_pos -= 1.0;
+                }
+                return None;
+            }
+            Ordering::Equal => return None,
         }
     }
 }


### PR DESCRIPTION
Clippy points out that said `if else` blocks can be replaced by `match` statements using `cmp`. Using `match` is slightly more performant than an equivalent `if else` block, thus using `match` is preferred in most cases where the same comparison is being done within a large `if else` block.