### PR TITLE
Add a Named component to "Spawnable" entities

### DIFF
--- a/src/components/consumable.rs
+++ b/src/components/consumable.rs
@@ -52,9 +52,6 @@ fn des_speed() -> f32 {
 }
 
 impl Spawnable for Consumable {
-    fn name(&self) -> String {
-        self.name.clone()
-    }
     fn init(&mut self) {}
 }
 

--- a/src/components/enemy.rs
+++ b/src/components/enemy.rs
@@ -246,10 +246,6 @@ impl Fires for Enemy {
 }
 
 impl Spawnable for Enemy {
-    fn name(&self) -> String {
-        self.name.clone()
-    }
-
     fn init(&mut self) {
         let mut rng = rand::thread_rng();
         let rand_num = rng.gen_range(0, 2);

--- a/src/components/item.rs
+++ b/src/components/item.rs
@@ -48,9 +48,6 @@ fn des_price() -> usize {
 }
 
 impl Spawnable for Item {
-    fn name(&self) -> String {
-        self.name.clone()
-    }
     fn init(&mut self) {}
 }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -193,6 +193,5 @@ pub trait Living {
 }
 
 pub trait Spawnable {
-    fn name(&self) -> String;
     fn init(&mut self);
 }

--- a/src/components/timelimit.rs
+++ b/src/components/timelimit.rs
@@ -8,9 +8,6 @@ pub struct TimeLimitComponent {
 }
 
 impl Spawnable for TimeLimitComponent {
-  fn name(&self) -> String {
-      "explosion".to_string()
-  }
   fn init(&mut self) {}
 }
 

--- a/src/entities/consumable.rs
+++ b/src/entities/consumable.rs
@@ -1,6 +1,6 @@
 use crate::{components::Consumable, resources::SpriteResource};
 use amethyst::{
-    core::math::Vector3,
+    core::{math::Vector3, Named},
     ecs::prelude::{Entities, LazyUpdate, ReadExpect},
     renderer::SpriteRender,
 };
@@ -16,5 +16,7 @@ pub fn spawn_consumable(
         sprite_sheet: sprite_resource.consumables_sprite_sheet.clone(),
         sprite_number: item.sprite_index,
     };
-    super::spawn_sprite_entity(&entities, sprite, item, spawn_position, &lazy_update);
+    let name = Named::new("consumable");
+
+    super::spawn_sprite_entity(&entities, name, sprite, item, spawn_position, &lazy_update);
 }

--- a/src/entities/enemy.rs
+++ b/src/entities/enemy.rs
@@ -1,7 +1,7 @@
 use crate::components::{Animation, Enemy};
 use amethyst::{
     assets::Handle,
-    core::math::Vector3,
+    core::{math::Vector3, Named},
     ecs::prelude::{Entities, Entity, LazyUpdate, ReadExpect},
     renderer::{SpriteRender, SpriteSheet},
 };
@@ -28,8 +28,11 @@ pub fn spawn_enemy(
         animation_type: item.animation_type.clone(),
     };
 
+    let name = Named::new("enemy");
+
     super::spawn_animated_entity(
         &entities,
+        name,
         sprite,
         animation,
         item,

--- a/src/entities/explosion.rs
+++ b/src/entities/explosion.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use amethyst::{
     assets::Handle,
-    core::math::Vector3,
+    core::{math::Vector3, Named},
     ecs::prelude::{Entities, LazyUpdate, ReadExpect},
     renderer::{SpriteRender, SpriteSheet},
 };
@@ -35,8 +35,11 @@ pub fn spawn_explosion(
         animation_type: AnimationType::Forward,
     };
 
+    let name = Named::new("explosion");
+
     super::spawn_animated_entity(
         &entities,
+        name,
         sprite,
         animation,
         TimeLimitComponent { duration },
@@ -77,9 +80,11 @@ pub fn spawn_blast_explosion(
         forward: true,
         animation_type: AnimationType::Forward,
     };
+    let name = Named::new("blast_explosion");
 
     super::spawn_animated_entity(
         &entities,
+        name,
         sprite,
         animation,
         TimeLimitComponent { duration },

--- a/src/entities/items.rs
+++ b/src/entities/items.rs
@@ -1,6 +1,6 @@
 use crate::{components::Item, resources::SpriteResource};
 use amethyst::{
-    core::math::Vector3,
+    core::{math::Vector3, Named},
     ecs::prelude::{Entities, LazyUpdate, ReadExpect},
     renderer::SpriteRender,
 };
@@ -16,5 +16,7 @@ pub fn spawn_item(
         sprite_sheet: item_resource.items_sprite_sheet.clone(),
         sprite_number: item.sprite_index,
     };
-    super::spawn_sprite_entity(&entities, sprite, item, spawn_position, &lazy_update);
+    let name = Named::new("item");
+
+    super::spawn_sprite_entity(&entities, name, sprite, item, spawn_position, &lazy_update);
 }

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -1,6 +1,6 @@
 use crate::components::Animation;
 use amethyst::{
-    core::{math::Vector3, transform::Transform},
+    core::{math::Vector3, transform::Transform, Named},
     ecs::prelude::{Builder, Component, Entities, Entity, LazyUpdate, ReadExpect},
     renderer::{SpriteRender, Transparent},
 };
@@ -42,6 +42,7 @@ use crate::components::Spawnable;
 
 fn spawn_sprite_entity<T: Spawnable + Component + Send + Sync>(
     entities: &Entities,
+    name: Named,
     sprite_render: SpriteRender,
     mut item_component: T,
     spawn_position: Vector3<f32>,
@@ -50,7 +51,7 @@ fn spawn_sprite_entity<T: Spawnable + Component + Send + Sync>(
     let mut local_transform = Transform::default();
     local_transform.set_translation(spawn_position);
 
-    println!("{} spawned!", item_component.name());
+    println!("{} spawned!", name.name);
     item_component.init();
 
     lazy_update
@@ -59,11 +60,13 @@ fn spawn_sprite_entity<T: Spawnable + Component + Send + Sync>(
         .with(item_component)
         .with(local_transform)
         .with(Transparent)
+        .with(name)
         .build();
 }
 
 fn spawn_animated_entity<T: Spawnable + Component + Send + Sync>(
     entities: &Entities,
+    name: Named,
     sprite_render: SpriteRender,
     animation: Animation,
     mut item_component: T,
@@ -73,7 +76,7 @@ fn spawn_animated_entity<T: Spawnable + Component + Send + Sync>(
     let mut local_transform = Transform::default();
     local_transform.set_translation(spawn_position);
 
-    println!("{} spawned!", item_component.name());
+    println!("{} spawned!", name.name);
     item_component.init();
 
     let enemy_entity: Entity = entities.create();
@@ -83,6 +86,7 @@ fn spawn_animated_entity<T: Spawnable + Component + Send + Sync>(
     lazy_update.insert(enemy_entity, item_component);
     lazy_update.insert(enemy_entity, local_transform);
     lazy_update.insert(enemy_entity, Transparent);
+    lazy_update.insert(enemy_entity, name);
 
     enemy_entity
 }


### PR DESCRIPTION
For #31

This patch removes the requirement for `name()` to be implemented for components implementing the Spawnable trait and instead adds the `Named` component for entities that are created with either `spawn_animated_entity` or `spawn_sprite_entity`.

Because of this, `spawn_animated_entity` and `spawn_sprite_entity` have an additional argument called `name`:

```rust
fn spawn_animated_entity<T: Spawnable + Component + Send + Sync>(
    entities: &Entities,
    name: Named,                       <-------- new argument here
    sprite_render: SpriteRender,
    animation: Animation,
    mut item_component: T,
    spawn_position: Vector3<f32>,
    lazy_update: &ReadExpect<LazyUpdate>,
) -> Entity {
  // ...
}
```

