### PR TITLE
Blast refactor

### DIFF
--- a/assets/data/enemies.ron
+++ b/assets/data/enemies.ron
@@ -53,7 +53,7 @@
         autoblaster_component: Some((
             count: 1,
             allied: false,
-            shot_velocity: [0.0, -60.0],
+            shot_velocity: [0.0, -150.0],
             offset: [0.0, -9.0],
             damage: 30.0,
             poison_damage: 0.0,
@@ -146,7 +146,7 @@
         autoblaster_component: Some((
             count: 1,
             allied: false,
-            shot_velocity: [0.0, -35.0],
+            shot_velocity: [0.0, -100.0],
             offset: [0.0, -6.0],
             damage: 20.0,
             poison_damage: 0.0,

--- a/assets/data/enemies.ron
+++ b/assets/data/enemies.ron
@@ -53,7 +53,8 @@
         autoblaster_component: Some((
             count: 1,
             allied: false,
-            shot_velocity: [0.0, -150.0],
+            shot_velocity: [0.0, -80.0],
+            velocity_multiplier: 0.5,
             offset: [0.0, -9.0],
             damage: 30.0,
             poison_damage: 0.0,
@@ -146,7 +147,8 @@
         autoblaster_component: Some((
             count: 1,
             allied: false,
-            shot_velocity: [0.0, -100.0],
+            shot_velocity: [0.0, -70.0],
+            velocity_multiplier: 0.5,
             offset: [0.0, -6.0],
             damage: 20.0,
             poison_damage: 0.0,

--- a/src/components/autoblaster.rs
+++ b/src/components/autoblaster.rs
@@ -10,7 +10,8 @@ pub struct AutoBlasterComponent {
     pub count: usize,
     pub allied: bool,
     pub shot_velocity: Vector2<f32>,
-    pub offset: Vector2<f32>, // spawn position of blasts offset from center of entity
+    pub velocity_multiplier: f32, // what percentage of the velocity from the source motion2d component will be added to the spawned blasts
+    pub offset: Vector2<f32>,     // spawn position of blasts offset from center of entity
     pub damage: f32,
     pub poison_damage: f32, // applies damage to blast when rolled
     pub poison_chance: f32,

--- a/src/components/blast.rs
+++ b/src/components/blast.rs
@@ -13,7 +13,6 @@ pub enum BlastType {
 pub struct Blast {
     pub damage: f32,
     pub poison_damage: f32,
-    pub velocity_factor: f32,
     pub blast_type: BlastType,
 }
 

--- a/src/components/blast.rs
+++ b/src/components/blast.rs
@@ -1,22 +1,19 @@
 use amethyst::ecs::prelude::{Component, DenseVecStorage};
 
+// used for setting sprite, status rolls, and which entities it can hit
 #[derive(Clone, Debug)]
 pub enum BlastType {
-    Player,
-    Poison,
-    Critical,
+    Ally,
     Enemy,
+    AllyPoison,
+    AllyCritical,
 }
 
 #[derive(Clone)]
 pub struct Blast {
-    pub speed: f32,
     pub damage: f32,
     pub poison_damage: f32,
-    pub x_velocity: f32,
-    pub y_velocity: f32,
     pub velocity_factor: f32,
-    pub allied: bool,
     pub blast_type: BlastType,
 }
 

--- a/src/components/blast.rs
+++ b/src/components/blast.rs
@@ -1,6 +1,6 @@
 use amethyst::ecs::prelude::{Component, DenseVecStorage};
 
-// used for setting sprite, status rolls, and which entities it can hit
+// used for setting sprite, status rolls, and the entity type spawning the blast
 #[derive(Clone, Debug)]
 pub enum BlastType {
     Ally,
@@ -10,12 +10,12 @@ pub enum BlastType {
 }
 
 #[derive(Clone)]
-pub struct Blast {
+pub struct BlastComponent {
     pub damage: f32,
     pub poison_damage: f32,
     pub blast_type: BlastType,
 }
 
-impl Component for Blast {
+impl Component for BlastComponent {
     type Storage = DenseVecStorage<Self>;
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -23,7 +23,7 @@ mod timelimit;
 pub use self::{
     animation::{Animation, AnimationType},
     autoblaster::AutoBlasterComponent,
-    blast::{Blast, BlastType},
+    blast::{BlastComponent, BlastType},
     boss::Repeater,
     consumable::Consumable,
     defense::Defense,

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -96,6 +96,10 @@ pub const DEFENSE_BAR_LIMIT: f32 = 63.0;
 pub const ROLL_BAR_X: f32 = 324.0;
 pub const ROLL_BAR_Y: f32 = 177.0;
 pub const ROLL_BAR_LIMIT: f32 = 28.0;
-pub const RESTOCK_BAR_X: f32 = 324.0; //should appear in arena
+pub const RESTOCK_BAR_X: f32 = 324.0;
 pub const RESTOCK_BAR_Y: f32 = 90.0;
 pub const RESTOCK_BAR_LIMIT: f32 = 28.0;
+
+// blasts
+pub const BLAST_MAX_SPEED_X: f32 = 1000.0; // blasts don't accelerate so this value should never be used
+pub const BLAST_MAX_SPEED_Y: f32 = 1000.0;

--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -99,7 +99,3 @@ pub const ROLL_BAR_LIMIT: f32 = 28.0;
 pub const RESTOCK_BAR_X: f32 = 324.0;
 pub const RESTOCK_BAR_Y: f32 = 90.0;
 pub const RESTOCK_BAR_LIMIT: f32 = 28.0;
-
-// blasts
-pub const BLAST_MAX_SPEED_X: f32 = 1000.0; // blasts don't accelerate so this value should never be used
-pub const BLAST_MAX_SPEED_Y: f32 = 1000.0;

--- a/src/entities/blast.rs
+++ b/src/entities/blast.rs
@@ -13,7 +13,6 @@ use crate::{
     constants::{
         BLAST_HITBOX_DIAMETER, BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y, BLAST_OFFSET,
         CRIT_BLAST_SPRITE_INDEX, PLAYER_BLAST_SPRITE_INDEX, POISON_BLAST_SPRITE_INDEX,
-        VELOCITY_FACTOR,
     },
     resources::SpriteResource,
 };
@@ -101,13 +100,8 @@ pub fn fire_blast(
         blast_spawn_pos += BLAST_OFFSET;
 
         let blast_component = Blast {
-            //speed: source_component.blast_speed(),
             damage,
             poison_damage,
-            //x_velocity: source_component.velocity_x(),
-            //y_velocity: source_component.velocity_y(),
-            velocity_factor: VELOCITY_FACTOR,
-            //allied: source_component.allied(),
             blast_type: blast_type.clone(),
         };
 

--- a/src/entities/blast.rs
+++ b/src/entities/blast.rs
@@ -9,10 +9,10 @@ use amethyst::{
 use rand::{thread_rng, Rng};
 
 use crate::{
-    components::{Blast, BlastType, Fires, Hitbox2DComponent, Motion2DComponent},
+    components::{BlastComponent, BlastType, Fires, Hitbox2DComponent, Motion2DComponent},
     constants::{
-        BLAST_HITBOX_DIAMETER, BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y, BLAST_OFFSET,
-        CRIT_BLAST_SPRITE_INDEX, PLAYER_BLAST_SPRITE_INDEX, POISON_BLAST_SPRITE_INDEX,
+        BLAST_HITBOX_DIAMETER, BLAST_OFFSET, CRIT_BLAST_SPRITE_INDEX, PLAYER_BLAST_SPRITE_INDEX,
+        POISON_BLAST_SPRITE_INDEX,
     },
     resources::SpriteResource,
 };
@@ -22,7 +22,7 @@ pub fn spawn_blasts(
     blast_count: usize,
     blast_spacing: f32,
     blast_sprite_render: SpriteRender,
-    blast_component: Blast,
+    blast_component: BlastComponent,
     blast_hitbox: Hitbox2DComponent,
     blast_motion2d: Motion2DComponent,
     mut blast_transform: Transform,
@@ -99,7 +99,7 @@ pub fn fire_blast(
 
         blast_spawn_pos += BLAST_OFFSET;
 
-        let blast_component = Blast {
+        let blast_component = BlastComponent {
             damage,
             poison_damage,
             blast_type: blast_type.clone(),
@@ -112,8 +112,8 @@ pub fn fire_blast(
             ),
             acceleration: Vector2::new(0.0, 0.0),
             deceleration: Vector2::new(0.0, 0.0),
-            max_speed: Vector2::new(BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y),
-            knockback_max_speed: Vector2::new(BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y),
+            max_speed: Vector2::new(1000.0, 1000.0),
+            knockback_max_speed: Vector2::new(1000.0, 1000.0),
             angular_velocity: 0.0,
             angular_acceleration: 0.0,
             angular_deceleration: 0.0,

--- a/src/entities/explosion.rs
+++ b/src/entities/explosion.rs
@@ -64,10 +64,10 @@ pub fn spawn_blast_explosion(
     let duration: f32 = frame_time * (frame_count - 1) as f32;
 
     let starting_frame: usize = match blast_type {
-        BlastType::Player => 0,
+        BlastType::Ally => 0,
         BlastType::Enemy => 7,
-        BlastType::Critical => 14,
-        BlastType::Poison => 21,
+        BlastType::AllyCritical => 14,
+        BlastType::AllyPoison => 21,
     };
 
     let sprite = SpriteRender {

--- a/src/entities/spaceship.rs
+++ b/src/entities/spaceship.rs
@@ -77,7 +77,7 @@ pub fn initialize_spaceship(world: &mut World, sprite_sheet_handle: Handle<Sprit
             barrel_action_timer: SPACESHIP_BARREL_DURATION,
             pos_x: local_transform.translation().x,
             pos_y: local_transform.translation().y,
-            blast_speed: 160.0,
+            blast_speed: 100.0,
             max_health: SPACESHIP_HEALTH,
             health: SPACESHIP_HEALTH,
             money: SPACESHIP_MONEY,

--- a/src/entities/spaceship.rs
+++ b/src/entities/spaceship.rs
@@ -77,7 +77,7 @@ pub fn initialize_spaceship(world: &mut World, sprite_sheet_handle: Handle<Sprit
             barrel_action_timer: SPACESHIP_BARREL_DURATION,
             pos_x: local_transform.translation().x,
             pos_y: local_transform.translation().y,
-            blast_speed: 100.0,
+            blast_speed: 160.0,
             max_health: SPACESHIP_HEALTH,
             health: SPACESHIP_HEALTH,
             money: SPACESHIP_MONEY,

--- a/src/systems/autoblaster_system.rs
+++ b/src/systems/autoblaster_system.rs
@@ -3,7 +3,7 @@ use crate::{
     constants::{
         BLAST_HITBOX_DIAMETER, BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y, BLAST_Z,
         CRIT_BLAST_SPRITE_INDEX, ENEMY_BLAST_SPRITE_INDEX, PLAYER_BLAST_SPRITE_INDEX,
-        POISON_BLAST_SPRITE_INDEX, VELOCITY_FACTOR,
+        POISON_BLAST_SPRITE_INDEX,
     },
     entities::spawn_blasts,
     resources::SpriteResource,
@@ -116,8 +116,10 @@ fn fire_when_ready(
 
         let blast_motion2d = Motion2DComponent {
             velocity: Vector2::new(
-                source_motion2d.velocity.x,
-                source_motion2d.velocity.y + autoblaster.shot_velocity.y,
+                (source_motion2d.velocity.x * autoblaster.velocity_multiplier)
+                    + autoblaster.shot_velocity.x,
+                (source_motion2d.velocity.y * autoblaster.velocity_multiplier)
+                    + autoblaster.shot_velocity.y,
             ),
             acceleration: Vector2::new(0.0, 0.0),
             deceleration: Vector2::new(0.0, 0.0),
@@ -131,7 +133,6 @@ fn fire_when_ready(
         let blast_component = Blast {
             damage: blast_damage,
             poison_damage: blast_poison_damage,
-            velocity_factor: VELOCITY_FACTOR,
             blast_type,
         };
 

--- a/src/systems/autoblaster_system.rs
+++ b/src/systems/autoblaster_system.rs
@@ -1,9 +1,10 @@
 use crate::{
-    components::{AutoBlasterComponent, Blast, BlastType, Hitbox2DComponent, Motion2DComponent},
+    components::{
+        AutoBlasterComponent, BlastComponent, BlastType, Hitbox2DComponent, Motion2DComponent,
+    },
     constants::{
-        BLAST_HITBOX_DIAMETER, BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y, BLAST_Z,
-        CRIT_BLAST_SPRITE_INDEX, ENEMY_BLAST_SPRITE_INDEX, PLAYER_BLAST_SPRITE_INDEX,
-        POISON_BLAST_SPRITE_INDEX,
+        BLAST_HITBOX_DIAMETER, BLAST_Z, CRIT_BLAST_SPRITE_INDEX, ENEMY_BLAST_SPRITE_INDEX,
+        PLAYER_BLAST_SPRITE_INDEX, POISON_BLAST_SPRITE_INDEX,
     },
     entities::spawn_blasts,
     resources::SpriteResource,
@@ -123,14 +124,14 @@ fn fire_when_ready(
             ),
             acceleration: Vector2::new(0.0, 0.0),
             deceleration: Vector2::new(0.0, 0.0),
-            max_speed: Vector2::new(BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y),
-            knockback_max_speed: Vector2::new(BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y),
+            max_speed: Vector2::new(1000.0, 1000.0),
+            knockback_max_speed: Vector2::new(1000.0, 1000.0),
             angular_velocity: 0.0,
             angular_acceleration: 0.0,
             angular_deceleration: 0.0,
         };
 
-        let blast_component = Blast {
+        let blast_component = BlastComponent {
             damage: blast_damage,
             poison_damage: blast_poison_damage,
             blast_type,

--- a/src/systems/autoblaster_system.rs
+++ b/src/systems/autoblaster_system.rs
@@ -1,15 +1,20 @@
 use crate::{
     components::{AutoBlasterComponent, Blast, BlastType, Hitbox2DComponent, Motion2DComponent},
     constants::{
-        BLAST_HITBOX_DIAMETER, BLAST_Z, CRIT_BLAST_SPRITE_INDEX, ENEMY_BLAST_SPRITE_INDEX,
-        PLAYER_BLAST_SPRITE_INDEX, POISON_BLAST_SPRITE_INDEX, VELOCITY_FACTOR,
+        BLAST_HITBOX_DIAMETER, BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y, BLAST_Z,
+        CRIT_BLAST_SPRITE_INDEX, ENEMY_BLAST_SPRITE_INDEX, PLAYER_BLAST_SPRITE_INDEX,
+        POISON_BLAST_SPRITE_INDEX, VELOCITY_FACTOR,
     },
     entities::spawn_blasts,
     resources::SpriteResource,
 };
 
 use amethyst::{
-    core::{math::Vector3, timing::Time, transform::Transform},
+    core::{
+        math::{Vector2, Vector3},
+        timing::Time,
+        transform::Transform,
+    },
     ecs::prelude::{
         Entities, Join, LazyUpdate, Read, ReadExpect, ReadStorage, System, WriteStorage,
     },
@@ -73,19 +78,19 @@ fn fire_when_ready(
         let mut blast_type = if !autoblaster.allied {
             BlastType::Enemy // TODO: remove BlastType or "allied" bool. They store redundant info.
         } else {
-            BlastType::Player
+            BlastType::Ally
         };
 
         let blast_damage = autoblaster.damage
             * if thread_rng().gen::<f32>() < autoblaster.crit_chance {
-                blast_type = BlastType::Critical;
+                blast_type = BlastType::AllyCritical;
                 2.0
             } else {
                 1.0
             };
 
         let blast_poison_damage = if thread_rng().gen::<f32>() < autoblaster.poison_chance {
-            blast_type = BlastType::Poison;
+            blast_type = BlastType::AllyPoison;
             autoblaster.poison_damage
         } else {
             0.0
@@ -94,10 +99,10 @@ fn fire_when_ready(
         let blast_sprite_render = SpriteRender {
             sprite_sheet: sprite_resource.blasts_sprite_sheet.clone(),
             sprite_number: match blast_type {
-                BlastType::Player => PLAYER_BLAST_SPRITE_INDEX,
+                BlastType::Ally => PLAYER_BLAST_SPRITE_INDEX,
                 BlastType::Enemy => ENEMY_BLAST_SPRITE_INDEX,
-                BlastType::Critical => CRIT_BLAST_SPRITE_INDEX,
-                BlastType::Poison => POISON_BLAST_SPRITE_INDEX,
+                BlastType::AllyCritical => CRIT_BLAST_SPRITE_INDEX,
+                BlastType::AllyPoison => POISON_BLAST_SPRITE_INDEX,
             },
         };
 
@@ -109,14 +114,24 @@ fn fire_when_ready(
             offset_rotation: 0.0,
         };
 
+        let blast_motion2d = Motion2DComponent {
+            velocity: Vector2::new(
+                source_motion2d.velocity.x,
+                source_motion2d.velocity.y + autoblaster.shot_velocity.y,
+            ),
+            acceleration: Vector2::new(0.0, 0.0),
+            deceleration: Vector2::new(0.0, 0.0),
+            max_speed: Vector2::new(BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y),
+            knockback_max_speed: Vector2::new(BLAST_MAX_SPEED_X, BLAST_MAX_SPEED_Y),
+            angular_velocity: 0.0,
+            angular_acceleration: 0.0,
+            angular_deceleration: 0.0,
+        };
+
         let blast_component = Blast {
-            speed: autoblaster.shot_velocity.y,
             damage: blast_damage,
             poison_damage: blast_poison_damage,
-            x_velocity: source_motion2d.velocity.x, // TODO: remove speed and only use velocity
-            y_velocity: source_motion2d.velocity.y,
             velocity_factor: VELOCITY_FACTOR,
-            allied: autoblaster.allied,
             blast_type,
         };
 
@@ -145,6 +160,7 @@ fn fire_when_ready(
             blast_sprite_render,
             blast_component,
             blast_hitbox,
+            blast_motion2d,
             blast_transform,
             entities,
             lazy_update,

--- a/src/systems/blast.rs
+++ b/src/systems/blast.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Blast, Hitbox2DComponent, Motion2DComponent},
+    components::{BlastComponent, Hitbox2DComponent, Motion2DComponent},
     constants::{ARENA_MAX_X, ARENA_MAX_Y, ARENA_MIN_X, ARENA_MIN_Y},
 };
 use amethyst::{
@@ -12,7 +12,7 @@ pub struct BlastSystem;
 impl<'s> System<'s> for BlastSystem {
     type SystemData = (
         Entities<'s>,
-        ReadStorage<'s, Blast>,
+        ReadStorage<'s, BlastComponent>,
         ReadStorage<'s, Hitbox2DComponent>,
         ReadStorage<'s, Motion2DComponent>,
         WriteStorage<'s, Transform>,
@@ -23,7 +23,7 @@ impl<'s> System<'s> for BlastSystem {
         &mut self,
         (entities, blasts, hitboxes, motion2ds, mut transforms, time): Self::SystemData,
     ) {
-        for (blast_entity, blast_component, blast_transform, blast_hitbox, blast_motion2d) in
+        for (blast_entity, _blast_component, blast_transform, blast_hitbox, blast_motion2d) in
             (&*entities, &blasts, &mut transforms, &hitboxes, &motion2ds).join()
         {
             // delete blast if outside of the arena

--- a/src/systems/blast.rs
+++ b/src/systems/blast.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Blast, Hitbox2DComponent},
+    components::{Blast, Hitbox2DComponent, Motion2DComponent},
     constants::{ARENA_MAX_X, ARENA_MAX_Y, ARENA_MIN_X, ARENA_MIN_Y},
 };
 use amethyst::{
@@ -14,13 +14,17 @@ impl<'s> System<'s> for BlastSystem {
         Entities<'s>,
         ReadStorage<'s, Blast>,
         ReadStorage<'s, Hitbox2DComponent>,
+        ReadStorage<'s, Motion2DComponent>,
         WriteStorage<'s, Transform>,
         Read<'s, Time>,
     );
 
-    fn run(&mut self, (entities, blasts, hitboxes, mut transforms, time): Self::SystemData) {
-        for (blast_entity, blast_component, blast_transform, blast_hitbox) in
-            (&*entities, &blasts, &mut transforms, &hitboxes).join()
+    fn run(
+        &mut self,
+        (entities, blasts, hitboxes, motion2ds, mut transforms, time): Self::SystemData,
+    ) {
+        for (blast_entity, blast_component, blast_transform, blast_hitbox, blast_motion2d) in
+            (&*entities, &blasts, &mut transforms, &hitboxes, &motion2ds).join()
         {
             // delete blast if outside of the arena
             // TODO add hitbox to side panel
@@ -36,11 +40,10 @@ impl<'s> System<'s> for BlastSystem {
 
             // update position based on blast velocity
             blast_transform.prepend_translation_x(
-                blast_component.x_velocity * blast_component.velocity_factor * time.delta_seconds(),
+                blast_motion2d.velocity.x * blast_component.velocity_factor * time.delta_seconds(),
             );
             blast_transform.prepend_translation_y(
-                (blast_component.y_velocity * blast_component.velocity_factor
-                    + blast_component.speed)
+                (blast_motion2d.velocity.y * blast_component.velocity_factor)
                     * time.delta_seconds(),
             );
         }

--- a/src/systems/blast.rs
+++ b/src/systems/blast.rs
@@ -39,13 +39,9 @@ impl<'s> System<'s> for BlastSystem {
             }
 
             // update position based on blast velocity
-            blast_transform.prepend_translation_x(
-                blast_motion2d.velocity.x * blast_component.velocity_factor * time.delta_seconds(),
-            );
-            blast_transform.prepend_translation_y(
-                (blast_motion2d.velocity.y * blast_component.velocity_factor)
-                    * time.delta_seconds(),
-            );
+            blast_transform.prepend_translation_x(blast_motion2d.velocity.x * time.delta_seconds());
+            blast_transform
+                .prepend_translation_y((blast_motion2d.velocity.y) * time.delta_seconds());
         }
     }
 }

--- a/src/systems/enemy_hit.rs
+++ b/src/systems/enemy_hit.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Blast, Spaceship},
+    components::{Blast, BlastType, Spaceship},
     constants::EXPLOSION_Z,
     entities::spawn_blast_explosion,
     resources::SpriteResource,
@@ -57,32 +57,38 @@ impl<'s> System<'s> for EnemyHitSystem {
                 {
                     //first check if the blast is allied with the player
                     //if the blast collides with the player and the player is not currently barrel rolling the blast hits
-                    if !blast.allied
-                        && ((event.entity_a == blast_entity && event.entity_b == spaceship_entity)
-                            || (event.entity_a == spaceship_entity
-                                && event.entity_b == blast_entity))
-                        && !spaceship.barrel_action_left
-                        && !spaceship.barrel_action_right
-                    {
-                        entities
-                            .delete(blast_entity)
-                            .expect("unable to delete entity");
+                    match blast.blast_type {
+                        // using match here for ease of adding enemy blast effects (such as poison) in the future
+                        BlastType::Enemy => {
+                            if ((event.entity_a == blast_entity
+                                && event.entity_b == spaceship_entity)
+                                || (event.entity_a == spaceship_entity
+                                    && event.entity_b == blast_entity))
+                                && !spaceship.barrel_action_left
+                                && !spaceship.barrel_action_right
+                            {
+                                entities
+                                    .delete(blast_entity)
+                                    .expect("unable to delete entity");
 
-                        let explosion_position = Vector3::new(
-                            blast_transform.translation().x,
-                            blast_transform.translation().y,
-                            EXPLOSION_Z,
-                        );
+                                let explosion_position = Vector3::new(
+                                    blast_transform.translation().x,
+                                    blast_transform.translation().y,
+                                    EXPLOSION_Z,
+                                );
 
-                        spawn_blast_explosion(
-                            &entities,
-                            sprite_resource.blast_explosions_sprite_sheet.clone(),
-                            blast.blast_type.clone(),
-                            explosion_position,
-                            &lazy_update,
-                        );
+                                spawn_blast_explosion(
+                                    &entities,
+                                    sprite_resource.blast_explosions_sprite_sheet.clone(),
+                                    blast.blast_type.clone(),
+                                    explosion_position,
+                                    &lazy_update,
+                                );
 
-                        spaceship.health -= blast.damage;
+                                spaceship.health -= blast.damage;
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/src/systems/enemy_hit.rs
+++ b/src/systems/enemy_hit.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::{Blast, BlastType, Spaceship},
+    components::{BlastComponent, BlastType, Spaceship},
     constants::EXPLOSION_Z,
     entities::spawn_blast_explosion,
     resources::SpriteResource,
@@ -23,7 +23,7 @@ impl<'s> System<'s> for EnemyHitSystem {
         Read<'s, EventChannel<HitboxCollisionEvent>>,
         Entities<'s>,
         WriteStorage<'s, Spaceship>,
-        WriteStorage<'s, Blast>,
+        WriteStorage<'s, BlastComponent>,
         ReadStorage<'s, Transform>,
         ReadExpect<'s, SpriteResource>,
         ReadExpect<'s, LazyUpdate>,

--- a/src/systems/player_hit.rs
+++ b/src/systems/player_hit.rs
@@ -1,6 +1,6 @@
 use crate::{
     audio::{play_sfx, Sounds},
-    components::{Blast, BlastType, Enemy},
+    components::{BlastComponent, BlastType, Enemy},
     constants::EXPLOSION_Z,
     entities::spawn_blast_explosion,
     resources::SpriteResource,
@@ -28,7 +28,7 @@ impl<'s> System<'s> for PlayerHitSystem {
         Read<'s, EventChannel<HitboxCollisionEvent>>,
         Entities<'s>,
         WriteStorage<'s, Enemy>,
-        WriteStorage<'s, Blast>,
+        WriteStorage<'s, BlastComponent>,
         ReadStorage<'s, Transform>,
         Read<'s, AssetStorage<Source>>,
         ReadExpect<'s, Sounds>,
@@ -68,9 +68,9 @@ impl<'s> System<'s> for PlayerHitSystem {
                 {
                     match blast.blast_type {
                         BlastType::Ally | BlastType::AllyCritical | BlastType::AllyPoison => {
-                            if ((event.entity_a == blast_entity && event.entity_b == enemy_entity)
+                            if (event.entity_a == blast_entity && event.entity_b == enemy_entity)
                                 || (event.entity_a == enemy_entity
-                                    && event.entity_b == blast_entity))
+                                    && event.entity_b == blast_entity)
                             {
                                 entities
                                     .delete(blast_entity)

--- a/src/systems/player_hit.rs
+++ b/src/systems/player_hit.rs
@@ -1,6 +1,6 @@
 use crate::{
     audio::{play_sfx, Sounds},
-    components::{Blast, Enemy},
+    components::{Blast, BlastType, Enemy},
     constants::EXPLOSION_Z,
     entities::spawn_blast_explosion,
     resources::SpriteResource,
@@ -66,31 +66,41 @@ impl<'s> System<'s> for PlayerHitSystem {
                 for (blast_entity, blast, blast_transform) in
                     (&entities, &mut blasts, &transforms).join()
                 {
-                    if blast.allied
-                        && ((event.entity_a == blast_entity && event.entity_b == enemy_entity)
-                            || (event.entity_a == enemy_entity && event.entity_b == blast_entity))
-                    {
-                        entities
-                            .delete(blast_entity)
-                            .expect("unable to delete entity");
-                        play_sfx(&sounds.spaceship_hit_sfx, &storage, audio_output.as_deref());
+                    match blast.blast_type {
+                        BlastType::Ally | BlastType::AllyCritical | BlastType::AllyPoison => {
+                            if ((event.entity_a == blast_entity && event.entity_b == enemy_entity)
+                                || (event.entity_a == enemy_entity
+                                    && event.entity_b == blast_entity))
+                            {
+                                entities
+                                    .delete(blast_entity)
+                                    .expect("unable to delete entity");
+                                play_sfx(
+                                    &sounds.spaceship_hit_sfx,
+                                    &storage,
+                                    audio_output.as_deref(),
+                                );
 
-                        let explosion_position = Vector3::new(
-                            blast_transform.translation().x,
-                            blast_transform.translation().y,
-                            EXPLOSION_Z,
-                        );
+                                let explosion_position = Vector3::new(
+                                    blast_transform.translation().x,
+                                    blast_transform.translation().y,
+                                    EXPLOSION_Z,
+                                );
 
-                        spawn_blast_explosion(
-                            &entities,
-                            sprite_resource.blast_explosions_sprite_sheet.clone(),
-                            blast.blast_type.clone(),
-                            explosion_position,
-                            &lazy_update,
-                        );
+                                spawn_blast_explosion(
+                                    &entities,
+                                    sprite_resource.blast_explosions_sprite_sheet.clone(),
+                                    blast.blast_type.clone(),
+                                    explosion_position,
+                                    &lazy_update,
+                                );
 
-                        enemy.health -= blast.damage;
-                        enemy.poison = blast.poison_damage;
+                                enemy.health -= blast.damage;
+                                enemy.poison = blast.poison_damage;
+                            }
+                        }
+
+                        _ => {}
                     }
                 }
             }


### PR DESCRIPTION
For #48.

I ended up moving `velocity_factor` from the Blast component to the AutoBlasterComponent as `velocity_multiplier`. This had the effect of neutralizing the influence of the former `velocity_factor` from blasts from the Player because there is no ManualBlasterComponent yet #49. If you run the game you will notice that blasts from the player are much more influenced by the velocity of the player because they aren't being scaled.