### PR TITLE
add EnemyDestroyedEvent and EnemyDestroyedSystem

### DIFF
--- a/src/entities/consumable.rs
+++ b/src/entities/consumable.rs
@@ -9,7 +9,7 @@ pub fn spawn_consumable(
     entities: &Entities,
     sprite_resource: &ReadExpect<SpriteResource>,
     consumable: ConsumableEntityData,
-    spawn_position: Vector3<f32>,
+    spawn_position: &Vector3<f32>,
     lazy_update: &ReadExpect<LazyUpdate>,
 ) {
     let sprite_render = SpriteRender {
@@ -19,7 +19,7 @@ pub fn spawn_consumable(
     let name = Named::new("consumable");
 
     let mut local_transform = Transform::default();
-    local_transform.set_translation(spawn_position);
+    local_transform.set_translation(*spawn_position);
 
     lazy_update
         .create_entity(entities)

--- a/src/entities/explosion.rs
+++ b/src/entities/explosion.rs
@@ -14,7 +14,7 @@ pub fn spawn_explosion(
     entities: &Entities,
     sprite_resource: &ReadExpect<SpriteResource>,
     sprite_number: usize,
-    spawn_position: Vector3<f32>,
+    spawn_position: &Vector3<f32>,
     lazy_update: &ReadExpect<LazyUpdate>,
 ) -> Entity {
     let frame_time: f32 = 0.1;
@@ -41,7 +41,7 @@ pub fn spawn_explosion(
     let timed = TimeLimitComponent { duration };
 
     let mut local_transform = Transform::default();
-    local_transform.set_translation(spawn_position);
+    local_transform.set_translation(*spawn_position);
 
     lazy_update
         .create_entity(entities)

--- a/src/events/events.rs
+++ b/src/events/events.rs
@@ -1,0 +1,60 @@
+use amethyst::ecs::prelude::Entity;
+
+#[derive(Debug)]
+pub struct CollisionEvent {
+    pub entity_a: Entity,
+    pub type_a: String,
+    pub to_velocity_x_a: f32, //velocity of the entity acting on a
+    pub to_velocity_y_a: f32,
+    pub entity_b: Entity,
+    pub type_b: String,
+    pub to_velocity_x_b: f32, //velocity of the entity acting on b
+    pub to_velocity_y_b: f32,
+}
+
+impl CollisionEvent {
+    pub fn new(
+        entity_a: Entity,
+        type_a: String,
+        to_velocity_x_a: f32,
+        to_velocity_y_a: f32,
+        entity_b: Entity,
+        type_b: String,
+        to_velocity_x_b: f32,
+        to_velocity_y_b: f32,
+    ) -> CollisionEvent {
+        CollisionEvent {
+            entity_a,
+            type_a,
+            to_velocity_x_a,
+            to_velocity_y_a,
+            entity_b,
+            type_b,
+            to_velocity_x_b,
+            to_velocity_y_b,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct HitboxCollisionEvent {
+    pub entity_a: Entity,
+    pub entity_b: Entity,
+}
+
+impl HitboxCollisionEvent {
+    pub fn new(entity_a: Entity, entity_b: Entity) -> HitboxCollisionEvent {
+        HitboxCollisionEvent { entity_a, entity_b }
+    }
+}
+
+#[derive(Debug)]
+pub struct EnemyDestroyedEvent {
+    pub enemy: Entity,
+}
+
+impl EnemyDestroyedEvent {
+    pub fn new(enemy: Entity) -> EnemyDestroyedEvent {
+        EnemyDestroyedEvent { enemy }
+    }
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,0 +1,3 @@
+mod events;
+
+pub use self::events::{CollisionEvent, EnemyDestroyedEvent, HitboxCollisionEvent};

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,11 @@ use amethyst::{
     utils::application_root_dir,
 };
 
-mod audio;
+pub mod audio;
 pub mod components;
 pub mod constants;
 pub mod entities;
+pub mod events;
 pub mod resources;
 mod space_shooter;
 pub mod systems;

--- a/src/space_shooter.rs
+++ b/src/space_shooter.rs
@@ -23,54 +23,6 @@ use amethyst::{
 };
 use std::f32::consts::FRAC_PI_3;
 
-#[derive(Debug)]
-pub struct CollisionEvent {
-    pub entity_a: Entity,
-    pub type_a: String,
-    pub to_velocity_x_a: f32, //velocity of the entity acting on a
-    pub to_velocity_y_a: f32,
-    pub entity_b: Entity,
-    pub type_b: String,
-    pub to_velocity_x_b: f32, //velocity of the entity acting on b
-    pub to_velocity_y_b: f32,
-}
-
-impl CollisionEvent {
-    pub fn new(
-        entity_a: Entity,
-        type_a: String,
-        to_velocity_x_a: f32,
-        to_velocity_y_a: f32,
-        entity_b: Entity,
-        type_b: String,
-        to_velocity_x_b: f32,
-        to_velocity_y_b: f32,
-    ) -> CollisionEvent {
-        CollisionEvent {
-            entity_a,
-            type_a,
-            to_velocity_x_a,
-            to_velocity_y_a,
-            entity_b,
-            type_b,
-            to_velocity_x_b,
-            to_velocity_y_b,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct HitboxCollisionEvent {
-    pub entity_a: Entity,
-    pub entity_b: Entity,
-}
-
-impl HitboxCollisionEvent {
-    pub fn new(entity_a: Entity, entity_b: Entity) -> HitboxCollisionEvent {
-        HitboxCollisionEvent { entity_a, entity_b }
-    }
-}
-
 pub struct SpaceShooter {
     dispatcher: Dispatcher<'static, 'static>,
 }
@@ -142,6 +94,11 @@ impl Default for SpaceShooter {
                 )
                 .with(systems::AutoBlasterSystem, "autoblaster_system", &[])
                 .with(systems::ManualBlasterSystem, "manualblaster_system", &[])
+                .with(
+                    systems::EnemyDestroyedSystem::default(),
+                    "enemy_destroyed_system",
+                    &["enemy_system"],
+                )
                 .build(),
         }
     }

--- a/src/systems/collision_detection.rs
+++ b/src/systems/collision_detection.rs
@@ -1,6 +1,6 @@
 use crate::{
     components::{Enemy, Hitbox2DComponent, Motion2DComponent, Spaceship},
-    space_shooter::CollisionEvent,
+    events::CollisionEvent,
 };
 use amethyst::{
     core::transform::Transform,

--- a/src/systems/consumable.rs
+++ b/src/systems/consumable.rs
@@ -2,7 +2,7 @@ use crate::{
     audio::{play_sfx, Sounds},
     components::{Consumable, Defense, Hitbox2DComponent, Spaceship},
     constants::ARENA_MIN_Y,
-    space_shooter::HitboxCollisionEvent,
+    events::HitboxCollisionEvent,
 };
 use amethyst::{
     assets::AssetStorage,

--- a/src/systems/enemy_collision_handler.rs
+++ b/src/systems/enemy_collision_handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     audio::{play_sfx, Sounds},
     components::{Enemy, Motion2DComponent, Spaceship},
-    space_shooter::CollisionEvent,
+    events::CollisionEvent,
 };
 use amethyst::{
     assets::AssetStorage,

--- a/src/systems/enemy_destroyed.rs
+++ b/src/systems/enemy_destroyed.rs
@@ -1,0 +1,95 @@
+use crate::{
+    audio::{play_sfx, Sounds},
+    components::{choose_random_name, Enemy},
+    entities::{spawn_consumable, spawn_explosion},
+    events::EnemyDestroyedEvent,
+    resources::{ConsumableEntityData, SpriteResource},
+};
+use amethyst::{
+    assets::AssetStorage,
+    audio::{output::Output, Source},
+    core::transform::Transform,
+    ecs::prelude::{Entities, Join, LazyUpdate, ReadExpect, ReadStorage, System},
+    ecs::*,
+    ecs::{Read, World},
+    shrev::{EventChannel, ReaderId},
+};
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct EnemyDestroyedSystem {
+    event_reader: Option<ReaderId<EnemyDestroyedEvent>>,
+}
+
+impl<'s> System<'s> for EnemyDestroyedSystem {
+    type SystemData = (
+        Read<'s, EventChannel<EnemyDestroyedEvent>>,
+        Entities<'s>,
+        ReadStorage<'s, Transform>,
+        ReadStorage<'s, Enemy>,
+        ReadExpect<'s, HashMap<String, ConsumableEntityData>>,
+        ReadExpect<'s, SpriteResource>,
+        ReadExpect<'s, LazyUpdate>,
+        Read<'s, AssetStorage<Source>>,
+        ReadExpect<'s, Sounds>,
+        Option<Read<'s, Output>>,
+    );
+
+    fn setup(&mut self, world: &mut World) {
+        Self::SystemData::setup(world);
+        self.event_reader = Some(
+            world
+                .fetch_mut::<EventChannel<EnemyDestroyedEvent>>()
+                .register_reader(),
+        );
+    }
+
+    fn run(
+        &mut self,
+        (
+            enemy_destroyed_event_channel,
+            entities,
+            transforms,
+            enemies,
+            consumable_pool,
+            sprite_resource,
+            lazy_update,
+            storage,
+            sounds,
+            audio_output,
+        ): Self::SystemData,
+    ) {
+        for event in enemy_destroyed_event_channel.read(self.event_reader.as_mut().unwrap()) {
+            for (enemy_entity, enemy_component, enemy_transform) in
+                (&entities, &enemies, &transforms).join()
+            {
+                if event.enemy == enemy_entity {
+                    play_sfx(&sounds.explosion_sfx, &storage, audio_output.as_deref());
+
+                    spawn_explosion(
+                        &entities,
+                        &sprite_resource,
+                        enemy_component.explosion_sprite_idx,
+                        enemy_transform.translation(),
+                        &lazy_update,
+                    );
+
+                    let name = choose_random_name(&enemy_component.collectables_probs);
+                    if !name.is_empty() {
+                        spawn_consumable(
+                            &entities,
+                            &sprite_resource,
+                            consumable_pool[name].clone(),
+                            enemy_transform.translation(),
+                            &lazy_update,
+                        );
+                    }
+
+                    entities
+                        .delete(enemy_entity)
+                        .expect("unable to delete entity");
+                }
+            }
+        }
+    }
+}

--- a/src/systems/enemy_hit.rs
+++ b/src/systems/enemy_hit.rs
@@ -1,8 +1,8 @@
 use crate::{
     components::{BlastComponent, BlastType, Spaceship},
     entities::spawn_blast_explosion,
+    events::HitboxCollisionEvent,
     resources::SpriteResource,
-    space_shooter::HitboxCollisionEvent,
 };
 use amethyst::{
     core::transform::Transform,

--- a/src/systems/hitbox_system.rs
+++ b/src/systems/hitbox_system.rs
@@ -1,4 +1,4 @@
-use crate::{components::Hitbox2DComponent, space_shooter::HitboxCollisionEvent};
+use crate::{components::Hitbox2DComponent, events::HitboxCollisionEvent};
 use amethyst::{
     core::transform::Transform,
     ecs::prelude::{Entities, Join, ReadStorage, System, Write},

--- a/src/systems/item.rs
+++ b/src/systems/item.rs
@@ -5,7 +5,7 @@ use crate::{
         Motion2DComponent, Spaceship,
     },
     constants::ARENA_MIN_Y,
-    space_shooter::HitboxCollisionEvent,
+    events::HitboxCollisionEvent,
 };
 use amethyst::{
     assets::AssetStorage,

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -7,6 +7,7 @@ mod consumable;
 mod defense;
 mod enemy;
 mod enemy_collision_handler;
+mod enemy_destroyed;
 mod enemy_hit;
 mod enemy_spawn;
 mod gamemaster;
@@ -27,10 +28,10 @@ pub use self::{
     animation::AnimationSystem, autoblaster_system::AutoBlasterSystem, blast::BlastSystem,
     boss::BossSystem, collision_detection::CollisionDetectionSystem, consumable::ConsumableSystem,
     defense::DefenseSystem, enemy::EnemySystem, enemy_collision_handler::EnemyCollisionSystem,
-    enemy_hit::EnemyHitSystem, enemy_spawn::SpawnerSystem, gamemaster::GameMasterSystem,
-    hitbox_system::HitboxSystem, item::ItemSystem, manualblaster_system::ManualBlasterSystem,
-    planets::PlanetsSystem, player_hit::PlayerHitSystem, spaceship::SpaceshipSystem,
-    spaceship_collision_handler::SpaceshipCollisionSystem,
+    enemy_destroyed::EnemyDestroyedSystem, enemy_hit::EnemyHitSystem, enemy_spawn::SpawnerSystem,
+    gamemaster::GameMasterSystem, hitbox_system::HitboxSystem, item::ItemSystem,
+    manualblaster_system::ManualBlasterSystem, planets::PlanetsSystem, player_hit::PlayerHitSystem,
+    spaceship::SpaceshipSystem, spaceship_collision_handler::SpaceshipCollisionSystem,
     spaceship_movement::SpaceshipMovementSystem, stat_tracker::StatTrackerSystem,
     status_bar::StatusBarSystem, store::StoreSystem, timelimit::TimeLimitSystem,
 };

--- a/src/systems/player_hit.rs
+++ b/src/systems/player_hit.rs
@@ -2,8 +2,8 @@ use crate::{
     audio::{play_sfx, Sounds},
     components::{BlastComponent, BlastType, Enemy},
     entities::spawn_blast_explosion,
+    events::HitboxCollisionEvent,
     resources::SpriteResource,
-    space_shooter::HitboxCollisionEvent,
 };
 use amethyst::{
     assets::AssetStorage,

--- a/src/systems/spaceship_collision_handler.rs
+++ b/src/systems/spaceship_collision_handler.rs
@@ -1,6 +1,6 @@
 use crate::{
     components::{Enemy, Motion2DComponent, Spaceship},
-    space_shooter::CollisionEvent,
+    events::CollisionEvent,
 };
 use amethyst::{
     ecs::*,


### PR DESCRIPTION
For #67.

I ended up creating a system to handle enemy deaths because spawning entities like the consumable drop and the blast explosion don't necessarily require their own system (I didn't want to create a new explosion system).

I see this event being read in other systems, for example, keeping track of how many enemies the player has destroyed.

I also moved all of the events currently in the game into their own module, rather than keeping them in the already large space_shooter.rs file.