### PR TITLE
Remove macos build task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR removes the build tasks for MacOS temporarily. Currently, compiling the project on MacOS will fail unless we change the following line from Cargo.toml: 
```
features = ["vulkan"] => features = ["metal"]
```

We can add this task back once #97 is fixed.